### PR TITLE
remove built ins from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,5 @@
 pandas
 plotnine
-json
-re
 torch
 numpy
-sklearn
-argparse
-random
+scikit-learn


### PR DESCRIPTION
The file `requirements.txt` contained some libraries such as `json` or `argparse` that are already installed with python3 and prevent reproducibility as installing requirement via `pip install -r requirements.txt` fails not finding candidates for those names.